### PR TITLE
Better err metric to compare the difference between two knn approaches

### DIFF
--- a/test.py
+++ b/test.py
@@ -60,9 +60,6 @@ if __name__ == "__main__":
 
         cart_coord = frac_coord @ lattice
         atomic_numbers = torch.tensor(config.atomic_numbers, dtype=torch.int64)
-        # print(f"frac_coord: {frac_coord}")
-        # print(f"lattice: {lattice}")
-        # print(f"atomic_numbers: {atomic_numbers}")
 
         radius=5
 


### PR DESCRIPTION
- I updated the logic to test if two graphs are the same. it's not that simple since they can be different, but the two graphs are equally good representations of the material
  - Since in our fast method, we feed in FEWER nodes into the knn algorithm, it outputs a different (but still optimal) result. This error metric is just some heuristics I came up with to determine how close the two knn generation algorithms are